### PR TITLE
Fix Python detection in conda and pixi environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/src/devtools/core/utils.py
+++ b/src/devtools/core/utils.py
@@ -60,6 +60,9 @@ def python_path() -> str:
     if platform.system() == "Windows":
         suffix = ".exe"
 
+        conda_python_path = qgis_path.parent.parent  # conda / pixi
+        search_paths.append(conda_python_path)
+
     if platform.system() == "Darwin":
         search_paths.append(qgis_path / "bin")  # brew
 


### PR DESCRIPTION
# What's New

- Fix Python executable detection for conda-forge and pixi QGIS installations on Windows.
- Fixes #10